### PR TITLE
fix: allow configure json library for supabase libs

### DIFF
--- a/lib/supabase.ex
+++ b/lib/supabase.ex
@@ -165,4 +165,9 @@ defmodule Supabase do
   defmacro __using__(which) when is_atom(which) do
     apply(__MODULE__, which, [])
   end
+
+  @doc "Returns the configured JSON encoding library for Supabase libraries."
+  def json_library do
+    Application.get_env(:supabase, :json_library, Jason)
+  end
 end

--- a/lib/supabase/fetcher/body_decoder.ex
+++ b/lib/supabase/fetcher/body_decoder.ex
@@ -35,6 +35,6 @@ defmodule Supabase.Fetcher.JSONDecoder do
   @impl true
   def decode(%Response{body: body}, opts \\ []) do
     keys = Keyword.get(opts, :keys, :strings)
-    Jason.decode(body, keys: keys)
+    Supabase.json_library().decode(body, keys: keys)
   end
 end

--- a/lib/supabase/fetcher/request.ex
+++ b/lib/supabase/fetcher/request.ex
@@ -196,14 +196,15 @@ defmodule Supabase.Fetcher.Request do
 
   @doc """
   Defines the request body to be sent, it can be a map, that will be encoded
-  with `Jason.encode_to_iodata!/1`, any `iodata` or a stream body in the pattern of `{:stream, Enumerable.t}`, although you will problably prefer to use the `upload/2`
+  with `encode_to_iodata!/1`, any `iodata` or a stream body in the pattern of `{:stream, Enumerable.t}`, although you will problably prefer to use the `upload/2`
   function of this module to hadle body stream since it will handle file management, content headers and so on.
   """
   @impl true
   def with_body(builder, body \\ nil)
 
   def with_body(%__MODULE__{} = builder, %{} = body) do
-    %{builder | body: Jason.encode_to_iodata!(body)}
+    json_library = Supabase.json_library()
+    %{builder | body: json_library.encode_to_iodata!(body)}
   end
 
   def with_body(%__MODULE__{} = builder, body) do

--- a/lib/supabase/fetcher/request/behaviour.ex
+++ b/lib/supabase/fetcher/request/behaviour.ex
@@ -14,7 +14,7 @@ defmodule Supabase.Fetcher.Request.Behaviour do
   @callback with_http_client(Request.t(), adapter :: module) :: Request.t()
   @callback with_query(Request.t(), query :: Enumerable.t()) :: Request.t()
   @callback with_body(Request.t(), body) :: Request.t()
-            when body: Jason.Encoder.t() | {:stream, Enumerable.t()} | nil
+            when body: term | {:stream, Enumerable.t()} | nil
   @callback with_headers(Request.t(), headers) :: Request.t()
             when headers: Supabase.Fetcher.headers()
   @callback with_body_decoder(Request.t(), decoder, decoder_opts) :: Request.t()

--- a/mix.exs
+++ b/mix.exs
@@ -33,8 +33,8 @@ defmodule Supabase.MixProject do
     [
       {:mime, "~> 2.0"},
       {:finch, "~> 0.16"},
-      {:jason, "~> 1.4"},
       {:ecto, "~> 3.10"},
+      {:jason, "~> 1.4", optional: true},
       {:mox, "~> 1.2", only: :test},
       {:ex_doc, ">= 0.0.0", only: [:dev], runtime: false},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},


### PR DESCRIPTION
## Problem

Some libraries from the elixir-supabase ecosystem are using `JSON` (native elixir module introduced on 1.18) and others are using `Jason` for JSON encoding, this creates a version mismatch for elixir version requirement since the `supabase-ex` supports from 1.16 to 1.18, so the rest of the libraries should do the same

## Solution

For that to work, i've introduced the `json_library` app config for `supabase`, similar to what Phoenix does, defaulting to `Jason` since historically is the most used JSON encoding library in elixir.

## Rationale

N/A
