### PR TITLE
build: add release-please version markers to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 Supabase Community Elixir SDK
 
+<!-- x-release-please-start-version -->
 ```elixir
 def deps do
   [
-    {:supabase_potion, "~> 0.6"}, # base SDK
+    {:supabase_potion, "~> 0.7.2"}, # base SDK
     {:supabase_storage, "~> 0.4"}, # storage integration
     {:supabase_auth, "~> 0.6"}, # auth integration
     {:supabase_postgrest, "~> 1.0"}, # postgrest integration
@@ -14,6 +15,7 @@ def deps do
   ]
 end
 ```
+<!-- x-release-please-end -->
 
 Individual product client documentation:
 


### PR DESCRIPTION
💁 These changes extend the existing Release Please configuration by wrapping the `supabase_potion` dep with `x-release-please-start-version` and `x-release-please-end markers` so the [generic extra-file updater can locate and bump the version on each release](https://github.com/googleapis/release-please/blob/main/docs/customizing.md#updating-arbitrary-files). Corrects the constraint from ~> 0.6 to ~> 0.7.2 to match the current release.