### PR TITLE
chore: remove unused functions

### DIFF
--- a/lib/supabase/application.ex
+++ b/lib/supabase/application.ex
@@ -5,7 +5,11 @@ defmodule Supabase.Application do
 
   @impl true
   def start(_start_type, _args) do
-    children = [{Finch, name: Supabase.Finch, pools: get_finch_pool()}]
+    children =
+      if start_default_finch?(),
+        do: [{Finch, name: Supabase.Finch, pools: get_finch_pool()}],
+        else: []
+
     opts = [strategy: :one_for_one, name: Supabase.Supervisor]
 
     Supervisor.start_link(children, opts)
@@ -19,19 +23,4 @@ defmodule Supabase.Application do
   defp get_finch_pool do
     Application.get_env(:supabase_potion, :finch_pool, %{default: [size: 10]})
   end
-
-  @spec maybe_append_child([child], (env -> boolean()), child) :: [child]
-        when env: :dev | :prod | :test | nil, child: Supervisor.module_spec()
-  defp maybe_append_child(children, pred, child) do
-    env = get_env()
-
-    cond do
-      is_nil(env) -> children
-      pred.(env) -> children ++ [child]
-      not pred.(env) -> children
-    end
-  end
-
-  @spec get_env :: :dev | :prod | :test | nil
-  defp get_env, do: Application.get_env(:supabase_potion, :env)
 end


### PR DESCRIPTION
During release `1.0.0` conflict solving i've wrongly merged old unused functions, which made the "Publish to Hex" action fail no compiling because of warnings.

I've solved them locally and published the version, so this pr only exists to update the remote repo from my local changes.
